### PR TITLE
Allow using libjit-sys with Rust 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ version = "0.4.0"
 name = "jit"
 path = "src/jit.rs"
 
+[dependencies]
+libc = "*"
+
 [dependencies.libjit-sys]
 path = "sys"
 version = "*"

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -26,7 +26,7 @@
 #![crate_name = "jit"]
 #![allow(raw_pointer_derive, non_camel_case_types, non_upper_case_globals)]
 #![deny(unused_attributes, dead_code, unused_parens, unknown_lints, unreachable_code, unused_allocation, unused_allocation, unused_must_use)]
-#![feature(alloc, libc, core, plugin, unboxed_closures, optin_builtin_traits, associated_consts)]
+#![feature(alloc, core, plugin, unboxed_closures, optin_builtin_traits, associated_consts)]
 #![plugin(rustc_bitflags)]
 
 //! This crate wraps LibJIT in an idiomatic style.

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -14,5 +14,8 @@ build = "build.rs"
 name = "libjit_sys"
 path = "lib.rs"
 
+[dependencies]
+libc = "*"
+
 [build-dependencies]
 pkg-config = "*"

--- a/sys/lib.rs
+++ b/sys/lib.rs
@@ -1,5 +1,4 @@
 #![allow(bad_style, missing_copy_implementations)]
-#![feature(libc)]
 
 extern crate libc;
 use libc::*;


### PR DESCRIPTION
This will provide low-level access to libjit-sys to people using Rust
1.0.  For the fun, high-level stuff, they'll still need to switch to the
nightly branch. :-)

To do this, I needed to do two things:

- Use the cargo-ized version of `libc`, because the in-compiler version
  probably won't be un-feature-gated in the immediate future.
- Replace `PathExt::exists` with a Rust-1.0-compatible implementation.

I tested this using multirust:

    cd jit.rs/sys
    multirust override stable
    cargo test

...and I tested the main library as usual using the nightly build:

    cd ..
    cargo test