### PR TITLE
Remove .cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,1 +1,0 @@
-paths = [ "sys", "macro", "." ]


### PR DESCRIPTION
Cargo now handles subcrates correctly. jit.rs can even be submitted to crates.io AFAICT.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tombebbington/jit.rs/12)
<!-- Reviewable:end -->
